### PR TITLE
Maintain a generation counter for function definitions

### DIFF
--- a/src/js/libcs/Evaluator.js
+++ b/src/js/libcs/Evaluator.js
@@ -7,7 +7,7 @@ function evaluate(a) {
         return nada;
     }
     if (a.ctype === 'infix') {
-        return a.impl(a.args, {});
+        return a.impl(a.args, {}, a);
     }
     if (a.ctype === 'variable') {
         return evaluate(namespace.getvar(a.name));

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -521,7 +521,7 @@ function infix_assign(args, modifs) {
 }
 
 
-function infix_define(args, modifs) {
+function infix_define(args, modifs, self) {
 
     var u0 = (args[0].ctype === 'undefined');
     var u1 = (args[1].ctype === 'undefined');
@@ -533,10 +533,22 @@ function infix_define(args, modifs) {
         var fname = args[0].oper;
         var ar = args[0].args;
         var body = args[1];
+        var generation = 1;
+        if (myfunctions.hasOwnProperty(fname)) {
+            var previous = myfunctions[fname];
+            if (previous.definer === self) {
+                // Redefinition using the same piece of code changes nothing.
+                // This needs some work once we have closures.
+                return nada;
+            }
+            generation = previous.generation + 1;
+        }
         myfunctions[fname] = {
             'oper': fname,
             'body': body,
-            'arglist': ar
+            'arglist': ar,
+            'definer': self,
+            'generation': generation
         };
     }
     if (args[0].ctype === 'variable') {


### PR DESCRIPTION
This should allow CindyGL to detect when a given function has changed, as discussed in https://github.com/CindyJS/CindyJS/pull/352#issuecomment-221551318. I haven't really tested this, so I hope you can hook up the CindyGL side of things and test whether this works as intended.
